### PR TITLE
Don't show the XA datasource password in clear text in the logs, show password placeholders

### DIFF
--- a/public/transactions-jdbc/src/main/java/com/atomikos/jdbc/AtomikosDataSourceBean.java
+++ b/public/transactions-jdbc/src/main/java/com/atomikos/jdbc/AtomikosDataSourceBean.java
@@ -71,10 +71,10 @@ extends AbstractDataSourceBean
 			ret.append ( "[" );
 			boolean first = true;
 			while ( it.hasMoreElements() ) {
-				String name = ( String ) it.nextElement();
-				if ( name.equals ( "password" ) ) continue;
 				if ( ! first ) ret.append ( "," );
+				String name = ( String ) it.nextElement();
 				String value = xaProperties.getProperty( name );
+				if ( name.equalsIgnoreCase ( "password" ) && value != null ) value = "********";
 				ret.append ( name ); ret.append ( "=" ); ret.append ( value );
 				first = false;
 			}

--- a/public/transactions-jdbc/src/main/java/com/atomikos/jdbc/AtomikosDataSourceBean.java
+++ b/public/transactions-jdbc/src/main/java/com/atomikos/jdbc/AtomikosDataSourceBean.java
@@ -71,9 +71,10 @@ extends AbstractDataSourceBean
 			ret.append ( "[" );
 			boolean first = true;
 			while ( it.hasMoreElements() ) {
-				if ( ! first ) ret.append ( "," );
 				String name = ( String ) it.nextElement();
-				String value = xaProperties.getProperty( name);
+				if ( name.equals ( "password" ) ) continue;
+				if ( ! first ) ret.append ( "," );
+				String value = xaProperties.getProperty( name );
 				ret.append ( name ); ret.append ( "=" ); ret.append ( value );
 				first = false;
 			}

--- a/public/transactions-jdbc/src/main/java/com/atomikos/jdbc/nonxa/AtomikosNonXADataSourceBean.java
+++ b/public/transactions-jdbc/src/main/java/com/atomikos/jdbc/nonxa/AtomikosNonXADataSourceBean.java
@@ -184,6 +184,7 @@ public class AtomikosNonXADataSourceBean extends AbstractDataSourceBean
 				" testQuery=" + getTestQuery() + "," +
 				" driverClassName=" + getDriverClassName() + "," +
 				" user=" + getUser() + "," +
+				" password=" + ( getPassword() != null ? "********" : null ) + "," +
 				" url=" + getUrl() + 
 				" loginTimeout=" + getLoginTimeout() +
 				"]"


### PR DESCRIPTION
Omits the password property when printing all the properties of the XA datasource
