### PR TITLE
Never print password in logs

### DIFF
--- a/public/transactions-jdbc/src/main/java/com/atomikos/jdbc/nonxa/AtomikosNonXADataSourceBean.java
+++ b/public/transactions-jdbc/src/main/java/com/atomikos/jdbc/nonxa/AtomikosNonXADataSourceBean.java
@@ -57,7 +57,25 @@ public class AtomikosNonXADataSourceBean extends AbstractDataSourceBean
 	private String driverClassName;
 	
 	private boolean readOnly;
-	
+
+	protected String printProperties() throws SQLException
+	{
+		return "[" +
+				" uniqueResourceName=" + getUniqueResourceName() + "," +
+				" maxPoolSize=" + getMaxPoolSize() + "," +
+				" minPoolSize=" + getMinPoolSize() + "," +
+				" borrowConnectionTimeout=" + getBorrowConnectionTimeout() + "," +
+				" maxIdleTime=" + getMaxIdleTime() + "," +
+				" reapTimeout=" + getReapTimeout() + "," +
+				" maintenanceInterval=" + getMaintenanceInterval() + "," +
+				" testQuery=" + getTestQuery() + "," +
+				" driverClassName=" + getDriverClassName() + "," +
+				" user=" + getUser() + "," +
+				" url=" + getUrl() + 
+				" loginTimeout=" + getLoginTimeout() +
+				"]";
+	}
+
 	/**
      * Sets the URL to use for getting connections. Required.
      * 
@@ -172,23 +190,8 @@ public class AtomikosNonXADataSourceBean extends AbstractDataSourceBean
 	protected ConnectionFactory doInit() throws Exception 
 	{
 		AtomikosNonXAConnectionFactory ret = null;
-		if ( LOGGER.isInfoEnabled() ) LOGGER.logInfo(
-				this + ": initializing with [" +
-				" uniqueResourceName=" + getUniqueResourceName() + "," +
-				" maxPoolSize=" + getMaxPoolSize() + "," +
-				" minPoolSize=" + getMinPoolSize() + "," +
-				" borrowConnectionTimeout=" + getBorrowConnectionTimeout() + "," +
-				" maxIdleTime=" + getMaxIdleTime() + "," +
-				" reapTimeout=" + getReapTimeout() + "," +
-				" maintenanceInterval=" + getMaintenanceInterval() + "," +
-				" testQuery=" + getTestQuery() + "," +
-				" driverClassName=" + getDriverClassName() + "," +
-				" user=" + getUser() + "," +
-				" url=" + getUrl() + 
-				" loginTimeout=" + getLoginTimeout() +
-				"]"
-				);
-		
+		if ( LOGGER.isInfoEnabled() )
+			LOGGER.logInfo( this + ": initializing with " + printProperties() );
 		
 		ret = new com.atomikos.jdbc.nonxa.AtomikosNonXAConnectionFactory ( this , url , driverClassName , user , password , getLoginTimeout() , readOnly ) ;
 		ret.init();

--- a/public/transactions-jdbc/src/test/java/com/atomikos/jdbc/AtomikosDataSourceBeanTestJUnit.java
+++ b/public/transactions-jdbc/src/test/java/com/atomikos/jdbc/AtomikosDataSourceBeanTestJUnit.java
@@ -1,0 +1,186 @@
+package com.atomikos.jdbc;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import java.sql.SQLException;
+import java.util.Properties;
+
+import javax.naming.Reference;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.atomikos.util.IntraVmObjectFactory;
+
+public class AtomikosDataSourceBeanTestJUnit {
+
+	private AtomikosDataSourceBean bean;
+	
+	@Before
+	public void setUp() throws Exception 
+	{
+		bean = new AtomikosDataSourceBean();
+	}
+	
+	@Test
+	public void testMinPoolSize() 
+	{
+		assertEquals ( 1 , bean.getMinPoolSize() );
+		bean.setMinPoolSize ( 2 );
+		assertEquals ( 2 , bean.getMinPoolSize() );
+	}
+	
+	@Test
+	public void testMaxPoolSize()
+	{
+		assertEquals ( 1 , bean.getMaxPoolSize() );
+		bean.setMaxPoolSize ( 3 );
+		assertEquals ( 3 , bean.getMaxPoolSize() );
+	}
+	
+	@Test
+	public void testPoolSize() 
+	{
+		assertEquals ( 1 , bean.getMaxPoolSize() );
+		assertEquals ( 1 , bean.getMinPoolSize() );
+		bean.setPoolSize ( 4 );
+		assertEquals ( 4 , bean.getMaxPoolSize() );
+		assertEquals ( 4 , bean.getMinPoolSize() );
+
+	}
+
+	@Test
+	public void testXaDataSourceClassName() 
+	{
+		assertEquals ( null , bean.getXaDataSourceClassName() );
+		String name = "blabla";
+		bean.setXaDataSourceClassName( name );
+		assertEquals ( name , bean.getXaDataSourceClassName() );
+	}
+	
+	@Test
+	public void testXaProperties()
+	{
+		assertTrue ( bean.getXaProperties().isEmpty() );
+		Properties p = new Properties();
+		String pname = "property";
+		String pvalue = "value";
+		p.setProperty ( pname , pvalue );
+		bean.setXaProperties ( p );
+		assertEquals ( p , bean.getXaProperties() );
+		assertEquals ( pvalue , bean.getXaProperties().getProperty(pname));
+		assertEquals ( p.size() , bean.getXaProperties().size() );
+	}
+	
+	@Test
+	public void testBorrowConnectionTimeout()
+	{
+		assertEquals ( 30 , bean.getBorrowConnectionTimeout() );
+		int timeout = 45;
+		bean.setBorrowConnectionTimeout ( timeout );
+		assertEquals ( 45 , bean.getBorrowConnectionTimeout() );
+	}
+	
+	@Test
+	public void testMaintenanceInterval()
+	{
+		assertEquals ( 60 , bean.getMaintenanceInterval() );
+		int interval = 90;
+		bean.setMaintenanceInterval ( interval );
+		assertEquals ( interval , bean.getMaintenanceInterval() );
+	}
+	
+	@Test
+	public void testMaxIdleTime() 
+	{
+		assertEquals ( 60 , bean.getMaxIdleTime() );
+		int time = 99;
+		bean.setMaxIdleTime ( time );
+		assertEquals ( time , bean.getMaxIdleTime() );
+	}
+	
+	@Test
+	public void testReapTimeout()
+	{
+		assertEquals ( 0 , bean.getReapTimeout() );
+		int timeout = 200;
+		bean.setReapTimeout ( timeout );
+		assertEquals ( timeout , bean.getReapTimeout() );
+	}
+	
+	@Test
+	public void testReferenceable() throws Exception 
+	{
+		bean.setUniqueResourceName ( "testReferenceable" );
+		Reference ref = bean.getReference();
+		assertNotNull ( ref );
+		IntraVmObjectFactory f = new IntraVmObjectFactory();
+		Object res = null;
+		res = f.getObjectInstance ( ref , null , null , null );
+		assertNotNull ( res );
+		assertSame ( bean , res );
+	}
+	
+	@Test
+	public void testUniqueResourceName()
+	{
+		assertNull ( bean.getUniqueResourceName() );
+		String name = "testname";
+		bean.setUniqueResourceName ( name );
+		assertEquals ( name , bean.getUniqueResourceName() );
+	}
+	
+	@Test
+	public void testTestQuery() 
+	{
+		assertNull ( bean.getTestQuery() );
+		String query = "testquery";
+		bean.setTestQuery ( query );
+		assertEquals ( query, bean.getTestQuery() );
+	}
+	
+	@Test
+	public void testLoginTimeout() throws SQLException
+	{
+		assertEquals ( 0, bean.getLoginTimeout() );
+		int timeout = 60;
+		bean.setLoginTimeout( timeout );
+		assertEquals ( timeout, bean.getLoginTimeout() );
+	}
+
+	@Test
+	public void testDefaultIsolationLevel() 
+	{
+		assertEquals ( -1 , bean.getDefaultIsolationLevel() );
+		int level = 1;
+		bean.setDefaultIsolationLevel( level );
+		assertEquals ( level , bean.getDefaultIsolationLevel() );
+	}
+	
+	@Test
+	public void testMaxLifetime() 
+	{
+		assertEquals ( 0 , bean.getMaxLifetime() );
+		int time = 99;
+		bean.setMaxLifetime ( time );
+		assertEquals ( time , bean.getMaxLifetime() );
+	}
+	
+	@Test
+	public void testPrintPropertiesSkipsPassword() throws Exception
+	{
+		Properties xaProperties = new Properties();
+		xaProperties.setProperty( "username", "johndoe" );
+		xaProperties.setProperty( "password", "secret" );
+		bean.setXaProperties( xaProperties );
+		String s = bean.printProperties();
+		assertTrue( s.contains( "username=johndoe" ) );
+		assertFalse( s.contains( "password=secret" ) );
+	}
+
+}

--- a/public/transactions-jdbc/src/test/java/com/atomikos/jdbc/nonxa/AtomikosNonXADataSourceBeanTestJUnit.java
+++ b/public/transactions-jdbc/src/test/java/com/atomikos/jdbc/nonxa/AtomikosNonXADataSourceBeanTestJUnit.java
@@ -9,7 +9,6 @@ import static org.junit.Assert.fail;
 import java.sql.SQLException;
 
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -34,7 +33,7 @@ public class AtomikosNonXADataSourceBeanTestJUnit
 	@Test
 	public void testDriverClassName() 
 	{
-		Assert.assertNull ( ds.getDriverClassName() );
+		assertNull ( ds.getDriverClassName() );
 		String name = "driver";
 		ds.setDriverClassName ( name );
 		assertEquals ( name , ds.getDriverClassName() );

--- a/public/transactions-jdbc/src/test/java/com/atomikos/jdbc/nonxa/AtomikosNonXADataSourceBeanTestJUnit.java
+++ b/public/transactions-jdbc/src/test/java/com/atomikos/jdbc/nonxa/AtomikosNonXADataSourceBeanTestJUnit.java
@@ -1,31 +1,46 @@
 package com.atomikos.jdbc.nonxa;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import java.sql.SQLException;
 
-import junit.framework.TestCase;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
 
 import com.atomikos.jdbc.AtomikosSQLException;
 
-public class AtomikosNonXADataSourceBeanTestJUnit extends TestCase 
+public class AtomikosNonXADataSourceBeanTestJUnit
 {
 	private AtomikosNonXADataSourceBean ds;
 	
-	protected void setUp() {
+	@Before
+	public void setUp()
+	{
 		ds = new AtomikosNonXADataSourceBean();
 	}
 	
-	protected void tearDown() {
+	@After
+	public void tearDown()
+	{
 		if ( ds != null ) ds.close();
 	}
 	
+	@Test
 	public void testDriverClassName() 
 	{
-		assertNull ( ds.getDriverClassName() );
+		Assert.assertNull ( ds.getDriverClassName() );
 		String name = "driver";
 		ds.setDriverClassName ( name );
 		assertEquals ( name , ds.getDriverClassName() );
 	}
 	
+	@Test
 	public void testPassword()
 	{
 		assertNull ( ds.getPassword() );
@@ -34,6 +49,7 @@ public class AtomikosNonXADataSourceBeanTestJUnit extends TestCase
 		assertEquals ( pw , ds.getPassword() );
 	}
 	
+	@Test
 	public void testUrl()
 	{
 		assertNull ( ds.getUrl() );
@@ -42,6 +58,7 @@ public class AtomikosNonXADataSourceBeanTestJUnit extends TestCase
 		assertEquals ( url , ds.getUrl() );
 	}
 	
+	@Test
 	public void testUser()
 	{
 		assertNull ( ds.getUser() );
@@ -51,6 +68,7 @@ public class AtomikosNonXADataSourceBeanTestJUnit extends TestCase
 		
 	}
 	
+	@Test
 	public void testBorrowConnectionTimeout()
 	{
 		assertEquals ( 30 , ds.getBorrowConnectionTimeout() );
@@ -58,6 +76,7 @@ public class AtomikosNonXADataSourceBeanTestJUnit extends TestCase
 		assertEquals ( 14 , ds.getBorrowConnectionTimeout() );
 	}
 	
+	@Test
 	public void testLoginTimeout () throws SQLException
 	{
 		assertEquals ( 0 , ds.getLoginTimeout() );
@@ -65,6 +84,7 @@ public class AtomikosNonXADataSourceBeanTestJUnit extends TestCase
 		assertEquals ( 5 , ds.getLoginTimeout() );
 	}
 	
+	@Test
 	public void testMaintenanceInterval()
 	{
 		assertEquals ( 60 , ds.getMaintenanceInterval() );
@@ -72,6 +92,7 @@ public class AtomikosNonXADataSourceBeanTestJUnit extends TestCase
 		assertEquals ( 13 , ds.getMaintenanceInterval() );
 	}
 	
+	@Test
 	public void testMaxIdleTime()
 	{
 		assertEquals ( 60 , ds.getMaxIdleTime() );
@@ -79,6 +100,7 @@ public class AtomikosNonXADataSourceBeanTestJUnit extends TestCase
 		assertEquals ( 11 , ds.getMaxIdleTime() );
 	}
 	
+	@Test
 	public void testMaxPoolSize() 
 	{
 		assertEquals ( 1 , ds.getMaxPoolSize() );
@@ -86,6 +108,7 @@ public class AtomikosNonXADataSourceBeanTestJUnit extends TestCase
 		assertEquals ( 3 , ds.getMaxPoolSize() );
 	}
 	
+	@Test
 	public void testMinPoolSize() 
 	{
 		assertEquals ( 1 , ds.getMinPoolSize() );
@@ -93,6 +116,7 @@ public class AtomikosNonXADataSourceBeanTestJUnit extends TestCase
 		assertEquals ( 4 , ds.getMinPoolSize() );
 	}
 	
+	@Test
 	public void testPoolSize()
 	{
 		assertEquals ( 1 , ds.getMinPoolSize() );
@@ -103,6 +127,7 @@ public class AtomikosNonXADataSourceBeanTestJUnit extends TestCase
 		
 	}
 	
+	@Test
 	public void testReapTimeout()
 	{
 		assertEquals ( 0 , ds.getReapTimeout() );
@@ -110,6 +135,7 @@ public class AtomikosNonXADataSourceBeanTestJUnit extends TestCase
 		assertEquals ( 33 , ds.getReapTimeout() );
 	}
 	
+	@Test
 	public void testTestQuery()
 	{
 		assertNull ( ds.getTestQuery() );
@@ -118,6 +144,7 @@ public class AtomikosNonXADataSourceBeanTestJUnit extends TestCase
 		assertEquals ( query , ds.getTestQuery() );
 	}
 	
+	@Test
 	public void testUniqueResourceName() 
 	{
 		assertNull ( ds.getUniqueResourceName() );
@@ -126,6 +153,7 @@ public class AtomikosNonXADataSourceBeanTestJUnit extends TestCase
 		assertEquals ( name , ds.getUniqueResourceName()  );
 	}
 	
+	@Test
 	public void testInitWithDriverClassNotFoundThrowsMeaningfulException () throws SQLException
 	{
 		ds.setUniqueResourceName( "test" );
@@ -140,6 +168,7 @@ public class AtomikosNonXADataSourceBeanTestJUnit extends TestCase
 		}		
 	}
 	
+	@Test
 	public void testInitWithInvalidDriverClassThrowsMeaningfulException () throws SQLException
 	{
 		ds.setUniqueResourceName( "test" );
@@ -154,6 +183,7 @@ public class AtomikosNonXADataSourceBeanTestJUnit extends TestCase
 		}		
 	}
 	
+	@Test
 	public void testReadOnly() throws Exception 
 	{
 		assertFalse ( ds.getReadOnly() );
@@ -163,11 +193,22 @@ public class AtomikosNonXADataSourceBeanTestJUnit extends TestCase
 		assertFalse ( ds.getReadOnly() );
 	}
 	
+	@Test
 	public void testDefaultIsolationLevel() throws Exception 
 	{	
 		assertEquals ( -1 , ds.getDefaultIsolationLevel() );
 		ds.setDefaultIsolationLevel( 0 );
 		assertEquals ( 0 , ds.getDefaultIsolationLevel() );
+	}
+
+	@Test
+	public void testPrintPropertiesSkipsPassword() throws Exception
+	{
+		ds.setUser( "johndoe" );
+		ds.setPassword( "secret" );
+		String s = ds.printProperties();
+		assertTrue( s.contains( "user=johndoe" ) );
+		assertFalse( s.contains( "password=secret" ) );
 	}
 
 }

--- a/public/transactions-jms/src/test/java/com/atomikos/jms/AtomikosConnectionFactoryBeanTestJUnit.java
+++ b/public/transactions-jms/src/test/java/com/atomikos/jms/AtomikosConnectionFactoryBeanTestJUnit.java
@@ -1,24 +1,33 @@
 package com.atomikos.jms;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
 import java.util.Properties;
 
 import javax.naming.Reference;
 
-import junit.framework.TestCase;
+import org.junit.Before;
+import org.junit.Test;
 
 import com.atomikos.util.IntraVmObjectFactory;
 
-public class AtomikosConnectionFactoryBeanTestJUnit extends TestCase 
+public class AtomikosConnectionFactoryBeanTestJUnit 
 {
 
 	private AtomikosConnectionFactoryBean bean;
 	
-	protected void setUp() throws Exception 
+	@Before
+	public void setUp() throws Exception 
 	{
-		super.setUp();
 		bean = new AtomikosConnectionFactoryBean();
 	}
 	
+	@Test
 	public void testMinPoolSize() 
 	{
 		assertEquals ( 1 , bean.getMinPoolSize() );
@@ -26,6 +35,7 @@ public class AtomikosConnectionFactoryBeanTestJUnit extends TestCase
 		assertEquals ( 2 , bean.getMinPoolSize() );
 	}
 	
+	@Test
 	public void testMaxPoolSize()
 	{
 		assertEquals ( 1 , bean.getMaxPoolSize() );
@@ -33,6 +43,7 @@ public class AtomikosConnectionFactoryBeanTestJUnit extends TestCase
 		assertEquals ( 3 , bean.getMaxPoolSize() );
 	}
 	
+	@Test
 	public void testPoolSize() 
 	{
 		assertEquals ( 1 , bean.getMaxPoolSize() );
@@ -43,6 +54,7 @@ public class AtomikosConnectionFactoryBeanTestJUnit extends TestCase
 
 	}
 
+	@Test
 	public void testXaConnectionFactoryClassName() 
 	{
 		assertEquals ( null , bean.getXaConnectionFactoryClassName() );
@@ -51,6 +63,7 @@ public class AtomikosConnectionFactoryBeanTestJUnit extends TestCase
 		assertEquals ( name , bean.getXaConnectionFactoryClassName() );
 	}
 	
+	@Test
 	public void testXaProperties()
 	{
 		assertTrue ( bean.getXaProperties().isEmpty() );
@@ -64,14 +77,16 @@ public class AtomikosConnectionFactoryBeanTestJUnit extends TestCase
 		assertEquals ( p.size() , bean.getXaProperties().size() );
 	}
 	
+	@Test
 	public void testBorrowConnectionTimeout()
 	{
 		assertEquals ( 30 , bean.getBorrowConnectionTimeout() );
 		int timeout = 45;
 		bean.setBorrowConnectionTimeout ( timeout );
-		assertEquals ( 45 , bean.getBorrowConnectionTimeout() );
+		assertEquals ( timeout , bean.getBorrowConnectionTimeout() );
 	}
 	
+	@Test
 	public void testMaintenanceInterval()
 	{
 		assertEquals ( 60 , bean.getMaintenanceInterval() );
@@ -80,6 +95,7 @@ public class AtomikosConnectionFactoryBeanTestJUnit extends TestCase
 		assertEquals ( interval , bean.getMaintenanceInterval() );
 	}
 	
+	@Test
 	public void testMaxIdleTime() 
 	{
 		assertEquals ( 60 , bean.getMaxIdleTime() );
@@ -88,15 +104,16 @@ public class AtomikosConnectionFactoryBeanTestJUnit extends TestCase
 		assertEquals ( time , bean.getMaxIdleTime() );
 	}
 	
+	@Test
 	public void testReapTimeout()
 	{
 		assertEquals ( 0 , bean.getReapTimeout() );
 		int timeout = 200;
 		bean.setReapTimeout ( timeout );
 		assertEquals ( timeout , bean.getReapTimeout() );
-
 	}
 	
+	@Test
 	public void testReferenceable() throws Exception 
 	{
 		bean.setUniqueResourceName ( "testReferenceable" );
@@ -109,6 +126,7 @@ public class AtomikosConnectionFactoryBeanTestJUnit extends TestCase
 		assertSame ( bean , res );
 	}
 	
+	@Test
 	public void testUniqueResourceName()
 	{
 		assertNull ( bean.getUniqueResourceName() );
@@ -117,6 +135,7 @@ public class AtomikosConnectionFactoryBeanTestJUnit extends TestCase
 		assertEquals ( name , bean.getUniqueResourceName() );
 	}
 	
+	@Test
 	public void testLocalTransactionMode() 
 	{
 		assertFalse ( bean.getLocalTransactionMode() );
@@ -126,12 +145,35 @@ public class AtomikosConnectionFactoryBeanTestJUnit extends TestCase
 		assertFalse ( bean.getLocalTransactionMode() );
 	}
 	
-	public void testIgnoreSessionTransactedFlag() {
-		assertTrue(bean.getIgnoreSessionTransactedFlag());
-		bean.setIgnoreSessionTransactedFlag(false);
-		assertFalse(bean.getIgnoreSessionTransactedFlag());
-		bean.setIgnoreSessionTransactedFlag(true);
-		assertTrue(bean.getIgnoreSessionTransactedFlag());
-
+	@Test
+	public void testIgnoreSessionTransactedFlag()
+	{
+		assertTrue ( bean.getIgnoreSessionTransactedFlag() );
+		bean.setIgnoreSessionTransactedFlag ( false );
+		assertFalse ( bean.getIgnoreSessionTransactedFlag() );
+		bean.setIgnoreSessionTransactedFlag( true );
+		assertTrue ( bean.getIgnoreSessionTransactedFlag() );
 	}
+
+	@Test
+	public void testMaxLifetime() 
+	{
+		assertEquals ( 0 , bean.getMaxLifetime() );
+		int time = 99;
+		bean.setMaxLifetime ( time );
+		assertEquals ( time , bean.getMaxLifetime() );
+	}
+	
+	@Test
+	public void testPrintPropertiesSkipsPassword() throws Exception
+	{
+		Properties xaProperties = new Properties();
+		xaProperties.setProperty ( "username", "johndoe" );
+		xaProperties.setProperty ( "password", "secret" );
+		bean.setXaProperties ( xaProperties );
+		String s = bean.printProperties();
+		assertTrue ( s.contains( "username=johndoe" ) );
+		assertFalse ( s.contains( "password=secret" ) );
+	}
+
 }

--- a/public/transactions-jta/src/main/java/com/atomikos/datasource/xa/XAProperties.java
+++ b/public/transactions-jta/src/main/java/com/atomikos/datasource/xa/XAProperties.java
@@ -1,0 +1,55 @@
+package com.atomikos.datasource.xa;
+
+import java.io.Serializable;
+import java.util.Enumeration;
+import java.util.Properties;
+
+/**
+ * 
+ * Properties adapter class protecting password from being printed.
+ *
+ */
+public class XAProperties
+implements Serializable {
+
+	private static final long serialVersionUID = 1L;
+
+	private Properties xaProperties;
+
+	public XAProperties()
+	{
+		this( new Properties() );
+	}
+	
+	public XAProperties(Properties xaProperties)
+	{
+		this.xaProperties = xaProperties;
+	}
+
+	public Properties getProperties()
+	{
+		return xaProperties;
+	}
+
+	public String printProperties()
+	{
+		StringBuffer ret = new StringBuffer();
+		if ( xaProperties != null ) {
+			Enumeration<?> it = xaProperties.propertyNames();
+			ret.append ( "[" );
+			boolean first = true;
+			while ( it.hasMoreElements() ) {
+				String name = ( String ) it.nextElement();
+				if ( !"password".equalsIgnoreCase( name ) ) {
+					if ( ! first ) ret.append ( "," );
+					String value = xaProperties.getProperty( name );
+					ret.append ( name ).append ( "=" ).append ( value );
+					first = false;
+				}
+			}
+			ret.append ( "]" );
+		}
+		return ret.toString();
+	}
+
+}

--- a/public/transactions-jta/src/test/java/com/atomikos/datasource/xa/XAPropertiesTestJUnit.java
+++ b/public/transactions-jta/src/test/java/com/atomikos/datasource/xa/XAPropertiesTestJUnit.java
@@ -1,0 +1,35 @@
+package com.atomikos.datasource.xa;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Properties;
+
+import org.junit.Test;
+
+public class XAPropertiesTestJUnit {
+
+	@Test
+	public void testPrintPropertiesHandlesNullProperties() {
+		XAProperties xaprops = new XAProperties( null );
+		assertEquals( "", xaprops.printProperties() );
+	}
+
+	@Test
+	public void testPrintPropertiesHandlesEmptyProperties() {
+		XAProperties xaprops = new XAProperties();
+		assertEquals( "[]", xaprops.printProperties() );
+	}
+
+	@Test
+	public void testPrintPropertiesSkipsPassword() {
+		Properties props = new Properties();
+		props.setProperty( "user", "johndoe" );
+		props.setProperty( "password", "secret" );
+		props.setProperty( "Password", "secret" );
+		props.setProperty( "PASSWORD", "secret" );
+		props.setProperty( "custom", "value" );
+		XAProperties xaprops = new XAProperties( props );
+		assertEquals( "[user=johndoe,custom=value]", xaprops.printProperties() );
+	}
+
+}


### PR DESCRIPTION
@mches @GuyPardon I took a liberty to extend PR https://github.com/atomikos/transactions-essentials/pull/3 by applying consistent logic to protect password from being printed in logs in:
- `com.atomikos.jdbc.AbstractDataSourceBean`
- `com.atomikos.jdbc.nonxa.AtomikosNonXADataSourceBean`
- `com.atomikos.jms.AtomikosConnectionFactoryBean`

Difference to PR https://github.com/atomikos/transactions-essentials/pull/3 is that password property is simply omitted and not just masked. Rationale behind this decision is:
- Masking password only when it is set is a security risk, because it means it can be reverse engineered. Knowing that password will be masked only if it is empty means that when `***` string is not logged must mean password is empty.
- By omitting the password completely from the logs means it is fully protected and not compromised.

I also took a liberty to:
- Add missing tests for getters/setters
- Convert existing JUnit 3 tests I touched into JUnit 4 tests
