### PR TITLE
JDBC 4.2 specification 10.1.1

### DIFF
--- a/public/transactions-jdbc/src/main/java/com/atomikos/jdbc/nonxa/AtomikosNonXADataSourceBean.java
+++ b/public/transactions-jdbc/src/main/java/com/atomikos/jdbc/nonxa/AtomikosNonXADataSourceBean.java
@@ -194,6 +194,9 @@ public class AtomikosNonXADataSourceBean extends AbstractDataSourceBean
 
         previous.incUseCount();
         if ( LOGGER.isTraceEnabled() ) LOGGER.logTrace ( this + ": returning " + proxy );
+        if (!previous.isInTransaction() && proxy.getAutoCommit() == false) {
+            proxy.setAutoCommit(true);
+        }
 		return proxy;
 	}
 

--- a/public/transactions-jdbc/src/main/java/com/atomikos/jdbc/nonxa/AtomikosThreadLocalConnection.java
+++ b/public/transactions-jdbc/src/main/java/com/atomikos/jdbc/nonxa/AtomikosThreadLocalConnection.java
@@ -310,7 +310,7 @@ implements JtaAwareNonXaConnection
 	 *
 	 * @return
 	 */
-	private boolean isInTransaction()
+	boolean isInTransaction()
 	{
 		return transaction != null;
 	}


### PR DESCRIPTION
(...)
The default is for auto-commit mode to be enabled when the Connection
object is created.
(...)

This commit prevents case for connection outside tranasction
1. client get connection
2. client set auto commit to false
3. client close connection
4. new client get connection which initially auto commit = false