### PR TITLE
Fix osgi imports to allow exposing transactions as mbeans

### DIFF
--- a/public/transactions-osgi/osgi.bnd
+++ b/public/transactions-osgi/osgi.bnd
@@ -2,5 +2,5 @@ Bundle-Activator: com.atomikos.transactions.internal.AtomikosActivator
 Embed-Transitive: true
 Embed-Dependency: *;groupId=com.atomikos;inline=true
 Import-Package: javax.transaction;version="1.0.1",javax.transaction.xa;version="1.0.1",org.osgi.framework,javax.management;resolution:=optional,javax.naming.*,*;resolution:=optional
-Export-Package: com.atomikos.jdbc.*,com.atomikos.jms.*,com.atomikos.datasource.xa,com.atomikos.icatch.jta,com.atomikos.icatch.admin.jmx
+Export-Package: com.atomikos.jdbc.*,com.atomikos.jms.*,com.atomikos.datasource.xa,com.atomikos.icatch.jta,com.atomikos.icatch.admin,com.atomikos.icatch,com.atomikos.icatch.config,com.atomikos.recovery
 DynamicImport-Package: *


### PR DESCRIPTION
Exposing these packages makes it possible to work with admin transactions in an osgi context.