### PR TITLE
Pull request for Handling destroy connections asynchronously during refresh pool

### DIFF
--- a/public/transactions-jta/src/main/java/com/atomikos/datasource/pool/ConnectionPool.java
+++ b/public/transactions-jta/src/main/java/com/atomikos/datasource/pool/ConnectionPool.java
@@ -43,15 +43,7 @@ public abstract class ConnectionPool implements XPooledConnectionEventListener
 	private String name;
 	
 	// Executor Service for cleaning up Half broken connections in the Pool
-	final ExecutorService poolCleanupService = Executors.newSingleThreadExecutor(new ThreadFactory() {
-		@Override
-		public Thread newThread (Runnable r) {
-	        Thread thread = new Thread(r);
-	        thread.setDaemon(true);
-	        return thread;
-	    }
-	});
-
+	private ExecutorService poolCleanupService; 
 
 	public ConnectionPool ( ConnectionFactory connectionFactory , ConnectionPoolProperties properties ) throws ConnectionPoolException
 	{
@@ -72,8 +64,20 @@ public abstract class ConnectionPool implements XPooledConnectionEventListener
 		if ( LOGGER.isTraceEnabled() ) LOGGER.logTrace ( this + ": initializing..." );
 		addConnectionsIfMinPoolSizeNotReached();
 		launchMaintenanceTimer();
+		initializePoolCleanupService();
 	}
 
+	private void initializePoolCleanupService() {
+		poolCleanupService = Executors.newSingleThreadExecutor(new ThreadFactory() {
+			@Override
+			public Thread newThread (Runnable r) {
+		        Thread thread = new Thread(r);
+		        thread.setDaemon(true);
+		        return thread;
+		    }
+		});
+	}
+	
 	private void launchMaintenanceTimer() {
 		int maintenanceInterval = properties.getMaintenanceInterval();
 		if ( maintenanceInterval <= 0 ) {


### PR DESCRIPTION
Notes:
When there are half broken connections to the remote data sources, especially in the case of Network outage, destroying these stale connections takes a long time when called from refresh().
The changes attempts to handle the destroy operation asynchronously.

For details, please refer to the below github issue:
Issue# https://github.com/atomikos/transactions-essentials/issues/23