### PR TITLE
Include original exception in RollbackException

### DIFF
--- a/public/transactions-jta/src/main/java/com/atomikos/datasource/xa/XAResourceTransaction.java
+++ b/public/transactions-jta/src/main/java/com/atomikos/datasource/xa/XAResourceTransaction.java
@@ -389,7 +389,7 @@ public class XAResourceTransaction implements ResourceTransaction, Participant {
 			if (XAException.XA_RBBASE <= xaerr.errorCode
 					&& xaerr.errorCode <= XAException.XA_RBEND) {
 				LOGGER.logWarning(msg, xaerr); // see case 84253
-				throw new RollbackException(msg);
+				throw new RollbackException(msg, xaerr);
 			} else {
 				LOGGER.logError(msg, xaerr);
 				throw new SysException(msg, xaerr);
@@ -568,7 +568,7 @@ public class XAResourceTransaction implements ResourceTransaction, Participant {
 					throw new SysException(msg, xaerr);
 				else
 					throw new com.atomikos.icatch.RollbackException(
-							"Already rolled back in resource.");
+							"Already rolled back in resource.", xaerr);
 			} else {
 				switch (xaerr.errorCode) {
 				case XAException.XA_HEURHAZ:

--- a/public/transactions/src/main/java/com/atomikos/icatch/imp/CoordinatorStateHandler.java
+++ b/public/transactions/src/main/java/com/atomikos/icatch/imp/CoordinatorStateHandler.java
@@ -390,7 +390,11 @@ abstract class CoordinatorStateHandler
                     // 1PC and rolled back before commit arrived.
                     nextStateHandler = new TerminatedStateHandler ( this );
                     coordinator_.setStateHandler ( nextStateHandler );
-                    throw new RollbackException ( "Rolled back already." );
+                    if (!commitresult.getReplies().isEmpty()) {
+                        throw new RollbackException ( "Rolled back already.", commitresult.getReplies().get(0).getException() );
+                    } else {
+                        throw new RollbackException ( "Rolled back already." );
+                    }
                 } else if ( res == TerminationResult.HEUR_ROLLBACK ) {
                     nextStateHandler = new HeurAbortedStateHandler ( this );
                     coordinator_.setStateHandler ( nextStateHandler );


### PR DESCRIPTION
In case of a unique constraint violation, the actual violated constraint name is not shown to the application exception handler. This is because atomikos creates RollbackException without the original exception as a cause. This change adds the original exception to RollbackException and application can then dig inside the cause and show meaningful error to end user.