### PR TITLE
Add connection status check in pooled connection

### DIFF
--- a/public/transactions-jdbc/src/main/java/com/atomikos/jdbc/internal/AtomikosNonXAPooledConnection.java
+++ b/public/transactions-jdbc/src/main/java/com/atomikos/jdbc/internal/AtomikosNonXAPooledConnection.java
@@ -117,7 +117,14 @@ public class AtomikosNonXAPooledConnection extends AbstractXPooledConnection<Con
 			if ( LOGGER.isTraceEnabled() ) LOGGER.logTrace ( this + ": connection tested OK" );
 		}
 		else {
-			if ( LOGGER.isTraceEnabled() ) LOGGER.logTrace ( this + ": no test query, skipping test" );
+			if ( LOGGER.isTraceEnabled() ) LOGGER.logTrace ( this + ": no test query, testing connection with ping" );
+			try {
+				if (!connection.isValid(0)) {
+					throw new CreateConnectionException ( "Connection is not valid" );
+				}
+			} catch (SQLException e) {
+				throw new CreateConnectionException ( "Connection is not valid" );
+			}
 		}
 	}
 

--- a/public/transactions-jdbc/src/main/java/com/atomikos/jdbc/internal/AtomikosXAPooledConnection.java
+++ b/public/transactions-jdbc/src/main/java/com/atomikos/jdbc/internal/AtomikosXAPooledConnection.java
@@ -115,7 +115,14 @@ public class AtomikosXAPooledConnection extends AbstractXPooledConnection<Connec
 			if ( LOGGER.isTraceEnabled() ) LOGGER.logTrace ( this + ": connection tested OK" );
 		}
 		else {
-			if ( LOGGER.isTraceEnabled() ) LOGGER.logTrace ( this + ": no test query, skipping test" );
+			if ( LOGGER.isTraceEnabled() ) LOGGER.logTrace ( this + ": no test query, testing connection with ping" );
+			try {
+				if (!connection.isValid(0)) {
+					throw new CreateConnectionException ( "Connection is not valid" );
+				}
+			} catch (SQLException e) {
+				throw new CreateConnectionException ( "Connection is not valid" );
+			}
 		}
 	}
 


### PR DESCRIPTION
If testQuery is not configured, check connection.isValid() in testUnderlyingConnection() to avoid returning dead connections.