### PR TITLE
Remoting fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,23 @@ target/
 .hgignore
 .hgtags
 .project
+
+# intellij specific items
+**/*.iml
+**/*.idea
+
+# vscode specific items
+**/.vscode/
+
+# atomikos specific files
+**/tmlog*.log
+**/tmlog.lck
+
+# vim swap files
+**/*.swp
+
+# windows Thumbnail cache
+**/Thumbs.db
+
+# macos detritus
+**/.DS_Store

--- a/public/transactions-api/src/main/java/com/atomikos/icatch/ImportingTransactionManager.java
+++ b/public/transactions-api/src/main/java/com/atomikos/icatch/ImportingTransactionManager.java
@@ -48,9 +48,11 @@ package com.atomikos.icatch;
      * 
      */
      
-    Extent terminated(boolean commit) throws SysException, RollbackException;
+    Extent terminated(boolean commit, int responseCount) throws SysException, RollbackException;
 
-    
+    default Extent terminated(boolean commit) throws SysException, RollbackException {
+        return this.terminated(commit, 1);
+    }
  
     
 

--- a/public/transactions-api/src/main/java/com/atomikos/icatch/event/transaction/LocalSiblingCountEvent.java
+++ b/public/transactions-api/src/main/java/com/atomikos/icatch/event/transaction/LocalSiblingCountEvent.java
@@ -1,0 +1,37 @@
+package com.atomikos.icatch.event.transaction;
+
+import com.atomikos.icatch.event.Event;
+
+/**
+ * Event for notifying event listeners when local siblings are added or terminated
+ *
+ * @author Chris Matthews (github: chrisbmatthews)
+ */
+public class LocalSiblingCountEvent extends Event {
+    private int currentLocalSiblingsAdded = 0;
+    private int currentLocalSiblingsTerminated = 0;
+
+    public LocalSiblingCountEvent(int currentLocalSiblingsAdded, int currentLocalSiblingsTerminated) {
+        this.currentLocalSiblingsAdded = currentLocalSiblingsAdded;
+        this.currentLocalSiblingsTerminated = currentLocalSiblingsTerminated;
+    }
+
+    public LocalSiblingCountEvent() {
+    }
+
+    public int getCurrentLocalSiblingsAdded() {
+        return currentLocalSiblingsAdded;
+    }
+
+    public void setCurrentLocalSiblingsAdded(int currentLocalSiblingsAdded) {
+        this.currentLocalSiblingsAdded = currentLocalSiblingsAdded;
+    }
+
+    public int getCurrentLocalSiblingsTerminated() {
+        return currentLocalSiblingsTerminated;
+    }
+
+    public void setCurrentLocalSiblingsTerminated(int currentLocalSiblingsTerminated) {
+        this.currentLocalSiblingsTerminated = currentLocalSiblingsTerminated;
+    }
+}

--- a/public/transactions-remoting/src/main/java/com/atomikos/remoting/DefaultImportingTransactionManager.java
+++ b/public/transactions-remoting/src/main/java/com/atomikos/remoting/DefaultImportingTransactionManager.java
@@ -52,7 +52,7 @@ public class DefaultImportingTransactionManager implements ImportingTransactionM
 	}
 
 	@Override
-	public Extent terminated(boolean commit) throws SysException, RollbackException {
+	public Extent terminated(boolean commit, int responseCount) throws SysException, RollbackException {
 		Extent extent = null;
 		CompositeTransactionManager ctm = Configuration.getCompositeTransactionManager();
 		CompositeTransaction ct = ctm.getCompositeTransaction();
@@ -82,7 +82,7 @@ public class DefaultImportingTransactionManager implements ImportingTransactionM
 		} catch (URISyntaxException e) {
 			throw new SysException("Could not create URI for extent", e);
 		}
-		extent.add(new ParticipantAdapter(participantURI), 1);
+		extent.add(new ParticipantAdapter(participantURI), responseCount);
 		LOGGER.logDebug("Returning extent: " + extent);
 		return extent;
 	}

--- a/public/transactions-remoting/src/main/java/com/atomikos/remoting/support/ContainerInterceptorTemplate.java
+++ b/public/transactions-remoting/src/main/java/com/atomikos/remoting/support/ContainerInterceptorTemplate.java
@@ -45,16 +45,27 @@ public class ContainerInterceptorTemplate {
 	}
 
 	/**
-	 * Terminates an imported transaction.
-	 * 
-	 * @param error If false then rollback, else commit.
-	 * @return the extent, or null if no active transaction
+	 * Call thru to the full implementation but default the responseCount to 1
+	 * @param error
+	 * @return
 	 * @throws RollbackException
 	 */
 	public String onOutgoingResponse(boolean error) throws RollbackException {
+		return this.onOutgoingResponse(error, 1);
+	}
+
+	/**
+	 * Terminates an imported transaction.
+	 * 
+	 * @param error If false then rollback, else commit.
+	 * @param responseCount The number of local siblings started on this call
+	 * @return the extent, or null if no active transaction
+	 * @throws RollbackException
+	 */
+	public String onOutgoingResponse(boolean error, int responseCount) throws RollbackException {
 		if (getCurrentTransaction() != null ) {
 			try {
-				Extent extent = importingTransactionManager.terminated(!error);
+				Extent extent = importingTransactionManager.terminated(!error, responseCount);
 				if (extent != null) { // null on error
 					return extent.toString();
 				}

--- a/public/transactions/src/main/java/com/atomikos/icatch/imp/ActiveStateHandler.java
+++ b/public/transactions/src/main/java/com/atomikos/icatch/imp/ActiveStateHandler.java
@@ -251,9 +251,10 @@ class ActiveStateHandler extends CoordinatorStateHandler
             // in that case: first prepare and then do normal
             // 2PC commit
 
-            setGlobalSiblingCount ( 1 );
             prepareResult = prepare ();
-            
+            //Chris Matthews fix - moved this to be *after* the prepare
+            setGlobalSiblingCount ( 1 );
+
             if ( prepareResult != Participant.READ_ONLY ) {
             	commitWithAfterCompletionNotification ( new CommitCallback() {
             		public void doCommit()


### PR DESCRIPTION
This is an attempt to fix some edge cases for remoting.

Why this change?
- I noticed that when I make a remote call from a Client to a Service, the Client is 'in charge' of the overall transaction.
- The Service responds with an Atomikos-Extent.  Inside that Extent is a responseCount.  Before my change, the responseCount was *always* hardcoded to 1.
- I further noticed that when the Client tried to notify the various Services that it was time to commit, it would send a cascadeList down to each service.  This cascadeList should contain each transaction identifier + a count of what the Client believes is the 'sibling count' each downstream Service is aware of.
- So I believe the defect is that the Service *should* be returning the local siblings it started in that thread.  Instead, it always returns hardcoded 1.  My fix is to return the correct number of local siblings started inside the thread of any specific call.
- If the responseCount returned is not correct, the cascadeList sent by the Client later on has an incorrect count.  This leads the Service to claim it has detected Orphans.

It's possible my solution for getting the new local sibling count up to the TransactionAwareRestContainerFilter is inelegant; I'm using the build-in EventListener to do it.

- I also made a further change to move the reset of the global sibling count to happen *after* the commit on a 1pc.
